### PR TITLE
[LA-58] Enabled sequelize to use SSL for postgres dialect.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -41,6 +41,9 @@ var init = module.exports.init = function(callback) {
     'host': config.get('db.host'),
     'port': config.get('db.port'),
     'dialect': 'postgres',
+    'dialectOptions': {
+      'ssl': true
+    },
     'databaseVersion': config.get('db.version'),
   };
 


### PR DESCRIPTION
Minor change - enabled sequelize to use SSL for postgres dialect.