### PR TITLE
LA-111 - Fixing user resolution for Outcome related events where extensions are absent.

### DIFF
--- a/lib/caliper.js
+++ b/lib/caliper.js
@@ -175,7 +175,7 @@ var getOrCreateUser = function(ctx, statement, callback) {
 
   // TODO : Add support for other actor types like Organizations based on examples from Caliper spec.
   if (statement.actor.hasOwnProperty('type') && statement.actor.hasOwnProperty('id') && statement.actor.type === 'Person') {
-    canvas_global_user_id = statement.actor.extensions[0].entity_id;
+    canvas_global_user_id = statement.actor.id.split(':').pop();
 
     if(statement.actor.hasOwnProperty('extensions')) {
       external_id = statement.actor.extensions[0].user_login;


### PR DESCRIPTION
Currently Outcome related events do not have extensions containing user details. These are derived from id for UCSD demo. Fixes and updates are made to the caliper ingest. 
There should be a follow up with Instructure on making sure that user_login Ids are sent to all Caliper events.