### PR TITLE
Updated Caliper ingest function to accomodate IMS spec changes

### DIFF
--- a/lib/caliper.js
+++ b/lib/caliper.js
@@ -178,16 +178,17 @@ var getOrCreateUser = function(ctx, statement, callback) {
     canvas_global_user_id = statement.actor.id.split(':').pop();
 
     if(statement.actor.hasOwnProperty('extensions')) {
-      external_id = statement.actor.extensions[0].user_login;
+      external_id = _.values(statement.actor.extensions)[0].user_login;
     }
 
   } else if (statement.actor.hasOwnProperty('type') && statement.actor.type === 'SoftwareApplication') {
     try {
       if (statement.object.actor.hasOwnProperty('id') && statement.object.actor.hasOwnProperty('type') && statement.object.actor.type === 'Person') {
         canvas_global_user_id = statement.object.actor.id.split(':').pop();
-
+        // Currently Instructure feeds do not include user_login information denoting on whose behalf Software applications are runnning generating events.
+        // TODO: Follow up with Instrucutre to accomodate this information consistently.  
         if (statement.object.actor.hasOwnProperty('extensions')) {
-          external_id = statement.object.actor.extensions[0].user_login;
+          external_id = _.values(statement.object.actor.extensions)[0].user_login;
         }
 
       }


### PR DESCRIPTION
IMS updated the spec for extensions to be an object instead of an array. The new parsing is inline with IMS spec. The user related information which contains CalNet ID is packaged within the extensions. Hence, the changes to the ingest function.